### PR TITLE
Add support for multiple channel buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ pip install -r requirements.txt
 Run the script and configure the following options before clicking **開始偵測**:
 
 - **偵測區域** – Enter four numbers (x1, y1, x2, y2) or use the **拖曳設定** button to draw the region to capture.
-- **按鈕區域** – Enter the coordinates of the button to click when the text is not found. You can also drag to select a region; the script will click the center.
+- **按鈕區域** – Configure five buttons: **登入**, **選角色**, **目錄**, **隨機組隊**, and **確認**. Each accepts coordinates (x1 y1 x2 y2) or use **拖曳設定** to select the region to click. The first two buttons are clicked automatically when detection starts.
 - **偵測間隔(秒)** – How many seconds to wait between each OCR scan.
 - **偵測文字** – Space separated keywords that must all appear for the boss to be detected.
 
 The current mouse position is displayed at the top of the window to help determine coordinates.
 
-During detection the program captures the specified region every interval and performs OCR using Traditional Chinese (`chi_tra`). When all keywords are found, a notification window appears and a system sound plays. Otherwise, the script clicks the configured button region to change channels.
+During detection the program captures the specified region every interval and performs OCR using Traditional Chinese (`chi_tra`). When all keywords are found, a notification window appears and a system sound plays. Otherwise, the script clicks the **目錄**, **隨機組隊**, and **確認** buttons in order to change channels.
 
 Log messages display the OCR results and current status, including how many channel switches have occurred. Use **停止偵測** to end detection.


### PR DESCRIPTION
## Summary
- allow configuring five button regions for login, character selection, menu, random party and confirm
- automate clicks for login/character buttons on start and channel switching sequence in detection loop
- document new buttons in README

## Testing
- `python -m py_compile detect_boss_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685a78a8ef1c832cb0d9d3b08ec46212